### PR TITLE
Fix `verify`

### DIFF
--- a/src/elliptic_signature/core.clj
+++ b/src/elliptic_signature/core.clj
@@ -222,7 +222,7 @@
             (when
               (and
                 (not= R infinity)
-                (zero? (.compareTo (.mod ^BigInteger (:y P) two) zero))
+                (zero? (.compareTo (.mod ^BigInteger (:y R) two) zero))
                 (zero? (.compareTo ^BigInteger (:x R) r)))
               true)))))))
 


### PR DESCRIPTION
A slight typo fix that was causing verify to falsely answer true in some cases.

Now every test vector (https://bips.xyz/340#test-vectors-and-reference-code) should pass correctly for `verify`.